### PR TITLE
Add restricted picklist option

### DIFF
--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -299,8 +299,9 @@ type PicklistFieldRequired struct {
 }
 
 type PicklistField struct {
-	Label    string          `xml:"label"`
-	Picklist []PicklistValue `xml:"picklist>picklistValues"`
+	Label              string          `xml:"label"`
+	Picklist           []PicklistValue `xml:"picklist>picklistValues"`
+	RestrictedPicklist bool            `xml:"restricted"`
 }
 
 type BoolFieldRequired struct {


### PR DESCRIPTION
When creating a picklist field using `force field create My_Widget__c "Widget Type":picklist picklist:"Fancy, Standard"` it is not possible to specify if the picklist should be restricted to the given values. The Force CLI returns "ERROR: validation error: restrictedPicklist:false is not a valid option for field type picklist".

This PR would add the ability to specify `restrictedPicklist:false` when creating a new picklist field.